### PR TITLE
feat: add bi-directional conversion between COCO and YOLO formats wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # COCO2YOLO Kaggle
 
-A tool for converting COCO dataset to YOLO format in Kaggle environment. This tool is based on ultralytics/JSON2YOLO and optimized for Kaggle environment.
+A tool for converting between COCO and YOLO formats in Kaggle environment. This tool is based on ultralytics/JSON2YOLO and optimized for Kaggle environment, with added support for reverse conversion (YOLO to COCO).
+
+English | [中文](README.zh.md)
 
 ## Features
 
-- Automatically convert COCO JSON annotations to YOLO format
+- Bi-directional conversion between COCO and YOLO formats:
+  - COCO JSON annotations to YOLO format
+  - YOLO annotations to COCO JSON format
 - Intelligently handle Kaggle storage space limitations
 - Support parallel file operations for faster processing
 - Support segment annotations
@@ -74,33 +78,56 @@ dataset_path = convert_coco_dataset(
 
 ### Command Line Usage
 
+### COCO to YOLO Conversion
+
 #### Convert Labels Only (Default Mode)
 
 ```bash
-coco2yolo-kaggle --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
+coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
 ```
 
 By default, this will map the 91 COCO classes to 80 classes. If you want to keep the original 91 classes, use:
 
 ```bash
-coco2yolo-kaggle --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --no-cls91to80
+coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --no-cls91to80
 ```
 
 #### Copy Files Only (with Custom Directory Names)
 
 ```bash
-coco2yolo-kaggle --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+coco2yolo-kaggle coco2yolo --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
 ```
 
 #### Complete Process with Custom Directory Names
 
 ```bash
-coco2yolo-kaggle --mode=all --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+coco2yolo-kaggle coco2yolo --mode=all --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+```
+
+### YOLO to COCO Conversion
+
+#### Convert Labels Only Using Class Names
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --class-names="person,car,bicycle"
+```
+
+#### Convert Labels Only Using YAML File
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --yaml-path=/kaggle/input/yolo-dataset/data.yaml
+```
+
+#### Complete Process with Copying Images
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --final-dest=/kaggle/tmp/COCO --yaml-path=/kaggle/input/yolo-dataset/data.yaml --copy-images
 ```
 
 ## Class Mapping and Customizing Directory Structure
 
 ### Class Mapping
+
 - By default, the tool maps the original 91 COCO classes to the standard 80 classes (`cls91to80=True`)
 - To preserve the original 91 classes, use the `--no-cls91to80` flag
 
@@ -114,15 +141,17 @@ You can customize the directory names using these parameters:
 
 ## Kaggle Example Code
 
+### COCO to YOLO Example
+
 ```python
 # 1. Install the package
 !pip install coco2yolo-kaggle
 
 # 2. Convert labels only (with class mapping)
-!coco2yolo-kaggle --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
+!coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
 
 # 3. Copy dataset files with custom directory names
-!coco2yolo-kaggle --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+!coco2yolo-kaggle coco2yolo --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
 
 # 4. Train a YOLOv8 model
 !pip install ultralytics
@@ -139,6 +168,33 @@ names: ['person', 'bicycle', 'car', ... ] # Complete 80 class names
 # Train the model
 model = YOLO('yolov8n.pt')  # Use nano model
 results = model.train(data='coco.yaml', epochs=3, imgsz=640)
+```
+
+### YOLO to COCO Example
+
+```python
+# 1. Install the package
+!pip install coco2yolo-kaggle
+
+# 2. Convert YOLO labels to COCO format using a YAML file
+!coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --yaml-path=/kaggle/input/yolo-dataset/data.yaml
+
+# 3. Python API for full control
+from coco2yolo_kaggle import convert_yolo_dataset
+
+# Convert YOLO dataset to COCO with more options
+result = convert_yolo_dataset(
+    yolo_dataset_path='/kaggle/input/yolo-dataset',
+    output_dir='/kaggle/working/yolo_coco',
+    final_dest='/kaggle/tmp/COCO',
+    class_names=['person', 'car', 'bicycle'],  # Explicit class names
+    split_names=('train', 'val'),              # Dataset splits to process
+    image_ext='jpg',                           # Image file extension
+    copy_images=True,                          # Copy images to final destination
+    max_workers=8                              # Parallel processing threads
+)
+
+print(f"Generated annotation files: {result}")
 ```
 
 ## Acknowledgements

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,240 @@
+# COCO2YOLO Kaggle
+
+一个在Kaggle环境中用于COCO和YOLO格式之间相互转换的工具。该工具基于ultralytics/JSON2YOLO，并针对Kaggle环境进行了优化，增加了反向转换（YOLO到COCO）的支持。
+
+[English](README.md) | 中文
+
+## 功能特点
+
+- 支持COCO和YOLO格式的双向转换：
+  - COCO JSON标注转换为YOLO格式
+  - YOLO标注转换为COCO JSON格式
+- 智能处理Kaggle存储空间限制
+- 支持并行文件操作以加快处理速度
+- 支持分割标注（segment annotations）
+- 灵活的命令行操作
+- 可自定义目录结构
+
+## 安装
+
+```bash
+pip install coco2yolo-kaggle
+```
+
+## 使用方法
+
+### Python API
+
+#### 仅转换标签（COCO到YOLO）
+
+```python
+from coco2yolo_kaggle import convert_coco_labels
+
+# 仅转换标签
+labels_dir = convert_coco_labels(
+    json_dir="/kaggle/input/coco-2017-dataset/coco2017/annotations",
+    output_dir="/kaggle/working/coco_yolo",
+    use_segments=True,
+    cls91to80=True  # 将91个COCO类别映射到80个类别（默认：True）
+)
+```
+
+#### 仅复制文件（使用自定义目录名）
+
+```python
+from coco2yolo_kaggle import copy_dataset
+
+# 将数据集文件复制到最终目标位置
+dataset_path = copy_dataset(
+    json_dir="/kaggle/input/coco-2017-dataset/coco2017/annotations",
+    output_dir="/kaggle/working/coco_yolo",
+    final_dest="/kaggle/tmp/COCO2017",
+    max_workers=8,
+    train_dir_name="train",  # 自定义训练目录名（默认："train2017"）
+    val_dir_name="val"       # 自定义验证目录名（默认："val2017"）
+)
+```
+
+#### 完整转换过程（COCO到YOLO）
+
+```python
+from coco2yolo_kaggle import convert_coco_dataset
+
+# 完整处理过程，使用自定义目录名
+dataset_path = convert_coco_dataset(
+    json_dir="/kaggle/input/coco-2017-dataset/coco2017/annotations",
+    output_dir="/kaggle/working/coco_yolo",
+    final_dest="/kaggle/tmp/COCO2017",
+    use_segments=True,
+    cls91to80=True,  # 将91个COCO类别映射到80个类别（默认：True）
+    max_workers=8,
+    copy_files=True,  # 设置为False可跳过复制文件
+    train_dir_name="train",  # 自定义目标目录（默认："train2017"）
+    val_dir_name="val",      # 自定义目标目录（默认："val2017"）
+    src_train_dir_name="train2017",  # 源训练目录名
+    src_val_dir_name="val2017"       # 源验证目录名
+)
+```
+
+#### 仅转换标签（YOLO到COCO）
+
+```python
+from coco2yolo_kaggle import convert_yolo_labels
+
+# 使用YAML文件提供类别信息
+result = convert_yolo_labels(
+    yolo_dataset_path="/kaggle/input/yolo-dataset",
+    output_dir="/kaggle/working/yolo_coco",
+    yaml_path="/kaggle/input/yolo-dataset/data.yaml"
+)
+
+# 或者直接提供类别名称
+result = convert_yolo_labels(
+    yolo_dataset_path="/kaggle/input/yolo-dataset",
+    output_dir="/kaggle/working/yolo_coco",
+    class_names=["person", "car", "bicycle"]
+)
+```
+
+#### 完整转换过程（YOLO到COCO）
+
+```python
+from coco2yolo_kaggle import convert_yolo_dataset
+
+# 完整处理过程
+result = convert_yolo_dataset(
+    yolo_dataset_path="/kaggle/input/yolo-dataset",
+    output_dir="/kaggle/working/yolo_coco",
+    final_dest="/kaggle/tmp/COCO",
+    yaml_path="/kaggle/input/yolo-dataset/data.yaml",
+    copy_images=True,
+    max_workers=8
+)
+```
+
+### 命令行使用
+
+#### COCO到YOLO转换
+
+##### 仅转换标签（默认模式）
+
+```bash
+coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
+```
+
+默认情况下，这将把91个COCO类别映射到80个类别。如果要保留原始的91个类别，请使用：
+
+```bash
+coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --no-cls91to80
+```
+
+##### 仅复制文件（使用自定义目录名）
+
+```bash
+coco2yolo-kaggle coco2yolo --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+```
+
+##### 完整过程（使用自定义目录名）
+
+```bash
+coco2yolo-kaggle coco2yolo --mode=all --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+```
+
+#### YOLO到COCO转换
+
+##### 使用类别名称转换标签
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --class-names="person,car,bicycle"
+```
+
+##### 使用YAML文件转换标签
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --yaml-path=/kaggle/input/yolo-dataset/data.yaml
+```
+
+##### 完整过程（包含复制图像）
+
+```bash
+coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --final-dest=/kaggle/tmp/COCO --yaml-path=/kaggle/input/yolo-dataset/data.yaml --copy-images
+```
+
+## 类别映射和自定义目录结构
+
+### 类别映射
+
+- 默认情况下，该工具将原始的91个COCO类别映射到标准的80个类别（`cls91to80=True`）
+- 要保留原始的91个类别，请使用`--no-cls91to80`参数
+
+### 目录名称自定义
+您可以使用以下参数自定义目录名称：
+
+- `--train-dir-name`：设置目标训练目录名称（默认："train2017"）
+- `--val-dir-name`：设置目标验证目录名称（默认："val2017"）
+- `--src-train-dir`：源训练目录名称（默认："train2017"）
+- `--src-val-dir`：源验证目录名称（默认："val2017"）
+
+
+## Kaggle示例代码
+
+### COCO到YOLO示例
+
+```python
+# 1. 安装软件包
+!pip install coco2yolo-kaggle
+
+# 2. 仅转换标签（带类别映射）
+!coco2yolo-kaggle coco2yolo --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo
+
+# 3. 使用自定义目录名称复制数据集文件
+!coco2yolo-kaggle coco2yolo --mode=copy --json-dir=/kaggle/input/coco-2017-dataset/coco2017/annotations --output-dir=/kaggle/working/coco_yolo --final-dest=/kaggle/tmp/COCO2017 --train-dir-name=train --val-dir-name=val
+
+# 4. 训练YOLOv8模型
+!pip install ultralytics
+from ultralytics import YOLO
+
+# 创建带有自定义目录结构的数据集配置文件
+%%writefile coco.yaml
+path: /kaggle/tmp/COCO2017
+train: images/train  # 使用自定义目录名
+val: images/val      # 使用自定义目录名
+nc: 80
+names: ['person', 'bicycle', 'car', ... ] # 完整的80个类别名称
+
+# 训练模型
+model = YOLO('yolov8n.pt')  # 使用nano模型
+results = model.train(data='coco.yaml', epochs=3, imgsz=640)
+```
+
+### YOLO到COCO示例
+
+```python
+# 1. 安装软件包
+!pip install coco2yolo-kaggle
+
+# 2. 使用YAML文件将YOLO标签转换为COCO格式
+!coco2yolo-kaggle yolo2coco --yolo-dataset-path=/kaggle/input/yolo-dataset --output-dir=/kaggle/working/yolo_coco --yaml-path=/kaggle/input/yolo-dataset/data.yaml
+
+# 3. 使用Python API获得完全控制
+from coco2yolo_kaggle import convert_yolo_dataset
+
+# 使用更多选项将YOLO数据集转换为COCO
+result = convert_yolo_dataset(
+    yolo_dataset_path='/kaggle/input/yolo-dataset',
+    output_dir='/kaggle/working/yolo_coco',
+    final_dest='/kaggle/tmp/COCO',
+    class_names=['person', 'car', 'bicycle'],  # 明确指定类别名称
+    split_names=('train', 'val'),              # 要处理的数据集拆分
+    image_ext='jpg',                           # 图像文件扩展名
+    copy_images=True,                          # 将图像复制到最终目标
+    max_workers=8                              # 并行处理线程数
+)
+
+print(f"生成的标注文件: {result}")
+```
+
+## 致谢
+
+该工具基于[ultralytics/JSON2YOLO](https://github.com/ultralytics/JSON2YOLO)，感谢原作者的贡献。
+

--- a/coco2yolo_kaggle/__init__.py
+++ b/coco2yolo_kaggle/__init__.py
@@ -1,7 +1,9 @@
 from .general_json2yolo import convert_coco_json, coco91_to_coco80_class
 from .file_utils import copy_dir_parallel, move_dir
+from .yolo2coco import yolo_to_coco, yolo_to_coco_from_yaml
 
 import concurrent.futures
+import shutil
 
 __version__ = "0.1.0"
 
@@ -154,3 +156,123 @@ def convert_coco_dataset(
         print(f"Labels conversion complete! Location: {output_dir}")
         print(f"- Labels: {output_dir}/labels/")
         return output_dir
+
+
+def convert_yolo_labels(
+    yolo_dataset_path="/kaggle/input/yolo-dataset",
+    output_dir="/kaggle/working/yolo_coco",
+    class_names=None,
+    yaml_path=None,
+    split_names=("train", "val"),
+    image_ext="jpg"
+):
+    """
+    Convert YOLO format annotations to COCO format
+    
+    Parameters:
+        yolo_dataset_path: Path to YOLO dataset with labels/{train,val} and images/{train,val} structure
+        output_dir: Output directory for COCO annotations
+        class_names: List of class names or dict {class_id: class_name} (required if yaml_path not provided)
+        yaml_path: Path to YAML file with class names (alternative to class_names)
+        split_names: Dataset splits to process (default: ["train", "val"])
+        image_ext: Image file extension (default: "jpg")
+        
+    Returns:
+        Dictionary with paths to generated annotation files
+    """
+    if yaml_path:
+        return yolo_to_coco_from_yaml(
+            yolo_dataset_path=yolo_dataset_path,
+            output_dir=output_dir,
+            yaml_path=yaml_path,
+            split_names=split_names,
+            image_ext=image_ext,
+            copy_images=False
+        )
+    elif class_names:
+        return yolo_to_coco(
+            yolo_dataset_path=yolo_dataset_path,
+            output_dir=output_dir,
+            class_names=class_names,
+            split_names=split_names,
+            image_ext=image_ext,
+            copy_images=False
+        )
+    else:
+        raise ValueError("Either class_names or yaml_path must be provided")
+
+
+def convert_yolo_dataset(
+    yolo_dataset_path="/kaggle/input/yolo-dataset",
+    output_dir="/kaggle/working/yolo_coco",
+    final_dest="/kaggle/tmp/COCO2017",
+    class_names=None,
+    yaml_path=None,
+    split_names=("train", "val"),
+    image_ext="jpg",
+    copy_images=True,
+    max_workers=8
+):
+    """
+    Execute the complete YOLO to COCO dataset conversion process:
+    1. Convert YOLO labels to COCO JSON format
+    2. Optionally copy image files to final destination
+    
+    Parameters:
+        yolo_dataset_path: Path to YOLO dataset with labels/{train,val} and images/{train,val} structure
+        output_dir: Temporary output directory for annotations
+        final_dest: Final dataset directory
+        class_names: List of class names or dict {class_id: class_name} (required if yaml_path not provided)
+        yaml_path: Path to YAML file with class names (alternative to class_names)
+        split_names: Dataset splits to process (default: ["train", "val"])
+        image_ext: Image file extension (default: "jpg")
+        copy_images: Whether to copy images to final destination
+        max_workers: Number of parallel worker threads
+    
+    Returns:
+        Dictionary with paths to generated files
+    """
+    # 1. Convert labels
+    result = convert_yolo_labels(
+        yolo_dataset_path=yolo_dataset_path,
+        output_dir=output_dir,
+        class_names=class_names,
+        yaml_path=yaml_path,
+        split_names=split_names,
+        image_ext=image_ext
+    )
+    
+    # 2. Optionally copy images
+    if copy_images:
+        # Create destination directories
+        import os
+        os.makedirs(final_dest, exist_ok=True)
+        images_dest = os.path.join(final_dest, "images")
+        os.makedirs(images_dest, exist_ok=True)
+        
+        # Copy images for each split
+        for split in split_names:
+            src_images = os.path.join(yolo_dataset_path, "images", split)
+            dst_images = os.path.join(images_dest, split)
+            
+            if os.path.exists(src_images):
+                copy_dir_parallel(src_images, dst_images, max_workers=max_workers)
+                print(f"Copied images from {src_images} to {dst_images}")
+            else:
+                print(f"Warning: Source images directory {src_images} not found, skipping copy")
+        
+        # Copy annotations
+        annotations_dir = os.path.join(final_dest, "annotations")
+        os.makedirs(annotations_dir, exist_ok=True)
+        
+        for split, annotation_file in result.items():
+            dst_file = os.path.join(annotations_dir, os.path.basename(annotation_file))
+            shutil.copy2(annotation_file, dst_file)
+            result[split] = dst_file
+            print(f"Copied annotation file to {dst_file}")
+        
+        print(f"Dataset preparation complete! Location: {final_dest}")
+        print(f"- Images: {images_dest}")
+        print(f"- Annotations: {annotations_dir}")
+    
+    return result

--- a/coco2yolo_kaggle/cli.py
+++ b/coco2yolo_kaggle/cli.py
@@ -1,90 +1,162 @@
 import argparse
 from . import convert_coco_labels, copy_dataset, convert_coco_dataset
+from . import convert_yolo_labels, convert_yolo_dataset
 
 def main():
     """Command line interface entry point"""
-    parser = argparse.ArgumentParser(description='Convert COCO dataset to YOLO format and handle Kaggle storage limitations')
+    parser = argparse.ArgumentParser(description='Convert between COCO and YOLO formats and handle Kaggle storage limitations')
     
-    # Common parameters
-    parser.add_argument('--json-dir', type=str, 
+    # Add parent parser for common arguments
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument('--output-dir', type=str, 
+                        default='/kaggle/working',
+                        help='Output directory')
+    parent_parser.add_argument('--final-dest', type=str, 
+                        default='/kaggle/tmp/dataset',
+                        help='Final dataset directory (when copying files)')
+    parent_parser.add_argument('--max-workers', type=int, default=8,
+                        help='Number of parallel worker threads')
+    
+    # Create subparsers for different conversion directions
+    subparsers = parser.add_subparsers(dest='direction', help='Conversion direction')
+    
+    # COCO to YOLO subparser
+    coco2yolo_parser = subparsers.add_parser('coco2yolo', help='Convert COCO format to YOLO format',
+                                           parents=[parent_parser])
+    
+    # COCO to YOLO specific arguments
+    coco2yolo_parser.add_argument('--json-dir', type=str, 
                         default='/kaggle/input/coco-2017-dataset/coco2017/annotations',
                         help='COCO JSON annotation directory')
     
-    parser.add_argument('--output-dir', type=str, 
-                        default='/kaggle/working/coco_yolo',
-                        help='Output directory for YOLO labels')
-    
-    # Optional parameters
-    parser.add_argument('--final-dest', type=str, 
-                        default='/kaggle/tmp/COCO2017',
-                        help='Final dataset directory (when copying files)')
-    
-    parser.add_argument('--use-segments', action='store_true',
+    coco2yolo_parser.add_argument('--use-segments', action='store_true',
                         help='Whether to use segment annotations')
     
-    parser.add_argument('--no-cls91to80', action='store_false', dest='cls91to80',
+    coco2yolo_parser.add_argument('--no-cls91to80', action='store_false', dest='cls91to80',
                         help='Disable mapping 91 classes to 80 classes (enabled by default)')
     
-    parser.add_argument('--max-workers', type=int, default=8,
-                        help='Number of parallel worker threads')
-    
-    # Directory structure customization
-    parser.add_argument('--train-dir-name', type=str, default='train2017',
+    # Directory structure customization for COCO to YOLO
+    coco2yolo_parser.add_argument('--train-dir-name', type=str, default='train2017',
                         help='Destination train subdirectory name')
     
-    parser.add_argument('--val-dir-name', type=str, default='val2017',
+    coco2yolo_parser.add_argument('--val-dir-name', type=str, default='val2017',
                         help='Destination validation subdirectory name')
     
-    parser.add_argument('--src-train-dir', type=str, default='train2017',
+    coco2yolo_parser.add_argument('--src-train-dir', type=str, default='train2017',
                         help='Source train directory name')
     
-    parser.add_argument('--src-val-dir', type=str, default='val2017',
+    coco2yolo_parser.add_argument('--src-val-dir', type=str, default='val2017',
                         help='Source validation directory name')
     
-    # Command mode selection
-    parser.add_argument('--mode', type=str, choices=['convert', 'copy', 'all'], default='convert',
+    # Command mode selection for COCO to YOLO
+    coco2yolo_parser.add_argument('--mode', type=str, choices=['convert', 'copy', 'all'], default='convert',
                         help='Operation mode: convert (labels only), copy (after convert), or all (both)')
     
-    # Set cls91to80 to True by default
-    parser.set_defaults(cls91to80=True)
+    # Set cls91to80 to True by default for COCO to YOLO
+    coco2yolo_parser.set_defaults(cls91to80=True)
+    
+    # YOLO to COCO subparser
+    yolo2coco_parser = subparsers.add_parser('yolo2coco', help='Convert YOLO format to COCO format',
+                                           parents=[parent_parser])
+    
+    # YOLO to COCO specific arguments
+    yolo2coco_parser.add_argument('--yolo-dataset-path', type=str, 
+                        default='/kaggle/input/yolo-dataset',
+                        help='YOLO dataset path with labels/{train,val} and images/{train,val} structure')
+    
+    yolo2coco_parser.add_argument('--yaml-path', type=str, 
+                        help='Path to YAML file with class names')
+    
+    yolo2coco_parser.add_argument('--class-names', type=str, 
+                        help='Comma-separated list of class names (alternative to --yaml-path)')
+    
+    yolo2coco_parser.add_argument('--split-names', type=str, default='train,val',
+                        help='Comma-separated list of dataset splits to process')
+    
+    yolo2coco_parser.add_argument('--image-ext', type=str, default='jpg',
+                        help='Image file extension')
+    
+    yolo2coco_parser.add_argument('--copy-images', action='store_true',
+                        help='Copy images to final destination')
     
     args = parser.parse_args()
     
-    if args.mode == 'convert':
-        # Only convert labels
-        convert_coco_labels(
-            json_dir=args.json_dir,
-            output_dir=args.output_dir,
-            use_segments=args.use_segments,
-            cls91to80=args.cls91to80
-        )
-    elif args.mode == 'copy':
-        # Only copy files (assumes labels are already converted)
-        copy_dataset(
-            json_dir=args.json_dir,
-            output_dir=args.output_dir,
-            final_dest=args.final_dest,
-            max_workers=args.max_workers,
-            train_dir_name=args.train_dir_name,
-            val_dir_name=args.val_dir_name,
-            src_train_dir_name=args.src_train_dir,
-            src_val_dir_name=args.src_val_dir
-        )
-    elif args.mode == 'all':
-        # Do both conversion and copying
-        convert_coco_dataset(
-            json_dir=args.json_dir,
-            output_dir=args.output_dir,
-            final_dest=args.final_dest,
-            use_segments=args.use_segments,
-            cls91to80=args.cls91to80,
-            max_workers=args.max_workers,
-            copy_files=True,
-            train_dir_name=args.train_dir_name,
-            val_dir_name=args.val_dir_name,
-            src_train_dir_name=args.src_train_dir,
-            src_val_dir_name=args.src_val_dir
-        )
+    # If no direction specified, show help
+    if args.direction is None:
+        parser.print_help()
+        return
+    
+    # Handle COCO to YOLO conversions
+    if args.direction == 'coco2yolo':
+        if args.mode == 'convert':
+            # Only convert labels
+            convert_coco_labels(
+                json_dir=args.json_dir,
+                output_dir=args.output_dir,
+                use_segments=args.use_segments,
+                cls91to80=args.cls91to80
+            )
+        elif args.mode == 'copy':
+            # Only copy files (assumes labels are already converted)
+            copy_dataset(
+                json_dir=args.json_dir,
+                output_dir=args.output_dir,
+                final_dest=args.final_dest,
+                max_workers=args.max_workers,
+                train_dir_name=args.train_dir_name,
+                val_dir_name=args.val_dir_name,
+                src_train_dir_name=args.src_train_dir,
+                src_val_dir_name=args.src_val_dir
+            )
+        elif args.mode == 'all':
+            # Do both conversion and copying
+            convert_coco_dataset(
+                json_dir=args.json_dir,
+                output_dir=args.output_dir,
+                final_dest=args.final_dest,
+                use_segments=args.use_segments,
+                cls91to80=args.cls91to80,
+                max_workers=args.max_workers,
+                copy_files=True,
+                train_dir_name=args.train_dir_name,
+                val_dir_name=args.val_dir_name,
+                src_train_dir_name=args.src_train_dir,
+                src_val_dir_name=args.src_val_dir
+            )
+    
+    # Handle YOLO to COCO conversions
+    elif args.direction == 'yolo2coco':
+        # Process class names if provided as a comma-separated string
+        class_names = None
+        if args.class_names:
+            class_names = [name.strip() for name in args.class_names.split(',')]
+        
+        # Process split names
+        split_names = [name.strip() for name in args.split_names.split(',')]
+        
+        if args.copy_images:
+            # Full dataset conversion including copying images
+            convert_yolo_dataset(
+                yolo_dataset_path=args.yolo_dataset_path,
+                output_dir=args.output_dir,
+                final_dest=args.final_dest,
+                class_names=class_names,
+                yaml_path=args.yaml_path,
+                split_names=split_names,
+                image_ext=args.image_ext,
+                copy_images=True,
+                max_workers=args.max_workers
+            )
+        else:
+            # Labels conversion only
+            convert_yolo_labels(
+                yolo_dataset_path=args.yolo_dataset_path,
+                output_dir=args.output_dir,
+                class_names=class_names,
+                yaml_path=args.yaml_path,
+                split_names=split_names,
+                image_ext=args.image_ext
+            )
 
 if __name__ == "__main__":
     main()

--- a/coco2yolo_kaggle/yolo2coco.py
+++ b/coco2yolo_kaggle/yolo2coco.py
@@ -1,0 +1,234 @@
+import os
+import json
+import glob
+from PIL import Image
+import numpy as np
+from pathlib import Path
+
+def yolo_to_coco(
+    yolo_dataset_path,
+    output_dir,
+    class_names,
+    split_names=("train", "val"),
+    image_ext="jpg",
+    copy_images=False
+):
+    """
+    Convert YOLO format dataset to COCO format
+    
+    Args:
+        yolo_dataset_path: Path to YOLO dataset
+        output_dir: Output directory for COCO format data
+        class_names: List of class names or dict {class_id: class_name}
+        split_names: Dataset split names (default: ["train", "val"])
+        image_ext: Image file extension (default: "jpg")
+        copy_images: Whether to copy images to output directory (default: False)
+    
+    Returns:
+        Dictionary with paths to generated annotation files
+    """
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+    annotations_dir = os.path.join(output_dir, "annotations")
+    os.makedirs(annotations_dir, exist_ok=True)
+    
+    # Prepare class dictionary
+    if isinstance(class_names, dict):
+        class_dict = {int(k): v for k, v in class_names.items()}
+    else:
+        class_dict = {i: name for i, name in enumerate(class_names)}
+    
+    result_files = {}
+    
+    # Process each split (train/val)
+    for split in split_names:
+        # Define paths
+        labels_path = os.path.join(yolo_dataset_path, "labels", split)
+        images_path = os.path.join(yolo_dataset_path, "images", split)
+        
+        if not os.path.exists(labels_path):
+            print(f"Warning: {labels_path} does not exist, skipping {split} split")
+            continue
+        
+        if not os.path.exists(images_path):
+            print(f"Warning: {images_path} does not exist, skipping {split} split")
+            continue
+        
+        # Initialize COCO JSON structure
+        coco_json = {
+            "info": {
+                "description": f"Converted from YOLO format - {split} set",
+                "url": "",
+                "version": "1.0",
+                "year": 2024,
+                "contributor": "coco2yolo_kaggle",
+                "date_created": ""
+            },
+            "licenses": [
+                {
+                    "url": "",
+                    "id": 1,
+                    "name": "Unknown"
+                }
+            ],
+            "images": [],
+            "annotations": [],
+            "categories": []
+        }
+        
+        # Add categories
+        for class_id, class_name in class_dict.items():
+            coco_json["categories"].append({
+                "supercategory": "none",
+                "id": class_id + 1,  # COCO IDs start from 1
+                "name": class_name
+            })
+        
+        # Create output image directory if copying
+        if copy_images:
+            out_images_dir = os.path.join(output_dir, split)
+            os.makedirs(out_images_dir, exist_ok=True)
+        
+        # Process each label file
+        annotation_id = 1
+        for label_file in glob.glob(os.path.join(labels_path, "*.txt")):
+            base_name = os.path.basename(label_file)
+            image_name = os.path.splitext(base_name)[0] + f".{image_ext}"
+            image_path = os.path.join(images_path, image_name)
+            
+            # Skip if image doesn't exist
+            if not os.path.exists(image_path):
+                print(f"Warning: Image {image_path} not found, skipping label {label_file}")
+                continue
+            
+            # Get image dimensions
+            try:
+                with Image.open(image_path) as img:
+                    width, height = img.size
+            except Exception as e:
+                print(f"Error reading image {image_path}: {e}")
+                continue
+            
+            # Add image to COCO JSON
+            image_id = len(coco_json["images"]) + 1
+            coco_json["images"].append({
+                "license": 1,
+                "file_name": image_name,
+                "height": height,
+                "width": width,
+                "id": image_id
+            })
+            
+            # Copy image if requested
+            if copy_images:
+                dst_image = os.path.join(out_images_dir, image_name)
+                if not os.path.exists(dst_image):
+                    try:
+                        shutil.copy2(image_path, dst_image)
+                    except Exception as e:
+                        print(f"Error copying image {image_path}: {e}")
+            
+            # Process annotations
+            try:
+                with open(label_file, 'r') as f:
+                    for line in f:
+                        parts = line.strip().split()
+                        if len(parts) < 5:  # Class + 4 coords (bbox)
+                            continue
+                        
+                        class_id = int(parts[0])
+                        x_center, y_center, bbox_width, bbox_height = map(float, parts[1:5])
+                        
+                        # Convert YOLO normalized coordinates to COCO pixel coordinates
+                        x_min = int((x_center - bbox_width / 2) * width)
+                        y_min = int((y_center - bbox_height / 2) * height)
+                        bbox_width_px = int(bbox_width * width)
+                        bbox_height_px = int(bbox_height * height)
+                        
+                        # Ensure coordinates are valid
+                        x_min = max(0, x_min)
+                        y_min = max(0, y_min)
+                        bbox_width_px = min(bbox_width_px, width - x_min)
+                        bbox_height_px = min(bbox_height_px, height - y_min)
+                        
+                        # Add annotation to COCO JSON
+                        coco_json["annotations"].append({
+                            "segmentation": [],
+                            "area": bbox_width_px * bbox_height_px,
+                            "iscrowd": 0,
+                            "image_id": image_id,
+                            "bbox": [x_min, y_min, bbox_width_px, bbox_height_px],
+                            "category_id": class_id + 1,  # COCO IDs start from 1
+                            "id": annotation_id
+                        })
+                        annotation_id += 1
+                        
+                        # Handle segmentation if available (parts beyond the bbox)
+                        if len(parts) > 5:
+                            # Parse segmentation points (x1, y1, x2, y2, ...)
+                            segment_points = list(map(float, parts[5:]))
+                            # Convert normalized coordinates to pixel coordinates
+                            segment_px = []
+                            for i in range(0, len(segment_points), 2):
+                                if i + 1 < len(segment_points):
+                                    x = int(segment_points[i] * width)
+                                    y = int(segment_points[i + 1] * height)
+                                    segment_px.extend([x, y])
+                            
+                            if segment_px:
+                                coco_json["annotations"][-1]["segmentation"] = [segment_px]
+            
+            except Exception as e:
+                print(f"Error processing label file {label_file}: {e}")
+        
+        # Save COCO JSON file
+        output_json = os.path.join(annotations_dir, f"instances_{split}.json")
+        with open(output_json, 'w', encoding='utf-8') as f:
+            json.dump(coco_json, f, ensure_ascii=False, indent=4)
+        
+        result_files[split] = output_json
+        print(f"Created COCO annotations for {split} split: {output_json}")
+    
+    return result_files
+
+def yolo_to_coco_from_yaml(
+    yolo_dataset_path,
+    output_dir,
+    yaml_path,
+    split_names=("train", "val"),
+    image_ext="jpg",
+    copy_images=False
+):
+    """
+    Convert YOLO format dataset to COCO format using a YAML config file
+    
+    Args:
+        yolo_dataset_path: Path to YOLO dataset
+        output_dir: Output directory for COCO format data
+        yaml_path: Path to YAML file containing class names
+        split_names: Dataset split names (default: ["train", "val"])
+        image_ext: Image file extension (default: "jpg")
+        copy_images: Whether to copy images to output directory (default: False)
+    
+    Returns:
+        Dictionary with paths to generated annotation files
+    """
+    import yaml
+    
+    # Read YAML file
+    with open(yaml_path, 'r', encoding='utf-8') as f:
+        yaml_data = yaml.safe_load(f)
+    
+    # Get class names
+    class_names = yaml_data.get('names', [])
+    if not class_names:
+        raise ValueError(f"No class names found in YAML file: {yaml_path}")
+    
+    return yolo_to_coco(
+        yolo_dataset_path=yolo_dataset_path,
+        output_dir=output_dir,
+        class_names=class_names,
+        split_names=split_names,
+        image_ext=image_ext,
+        copy_images=copy_images
+    )


### PR DESCRIPTION
This pull request introduces bi-directional conversion support between COCO and YOLO formats, enhancing the tool's functionality and usability. Key changes include updates to the CLI, Python API, and documentation to support YOLO-to-COCO conversions alongside existing COCO-to-YOLO functionality.

### New Features:
* **Bi-directional Conversion Support**:
  - Added `convert_yolo_labels` and `convert_yolo_dataset` functions to handle YOLO-to-COCO conversions, with options for class names, YAML files, and image copying. (`coco2yolo_kaggle/__init__.py`, [coco2yolo_kaggle/__init__.pyR159-R278](diffhunk://#diff-3247a2fce390c292c7c51a08eb6ab96a3a39e6569a4e5accd1a369ca64e17c93R159-R278))
  - Updated CLI to include a `yolo2coco` subcommand with arguments for dataset path, class names, YAML file, and image copying. (`coco2yolo_kaggle/cli.py`, [[1]](diffhunk://#diff-9e0044566e6282fa4a77866585fc61bf39ecc970eed896dba5db84651e583131R3-R90) [[2]](diffhunk://#diff-9e0044566e6282fa4a77866585fc61bf39ecc970eed896dba5db84651e583131R127-R160)

### Documentation Updates:
* **README Enhancements**:
  - Highlighted the new YOLO-to-COCO functionality in the introduction and features section. (`README.md`, [README.mdL3-R11](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R11))
  - Added usage examples for YOLO-to-COCO conversions, including command-line and Python API examples. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R130) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R199)

### Codebase Improvements:
* **Code Organization**:
  - Refactored CLI to use subparsers for better separation of COCO-to-YOLO and YOLO-to-COCO commands. (`coco2yolo_kaggle/cli.py`, [coco2yolo_kaggle/cli.pyR3-R90](diffhunk://#diff-9e0044566e6282fa4a77866585fc61bf39ecc970eed896dba5db84651e583131R3-R90))
  - Imported new utility functions (`yolo_to_coco`, `yolo_to_coco_from_yaml`) for YOLO-to-COCO conversions. (`coco2yolo_kaggle/__init__.py`, [coco2yolo_kaggle/__init__.pyR3-R6](diffhunk://#diff-3247a2fce390c292c7c51a08eb6ab96a3a39e6569a4e5accd1a369ca64e17c93R3-R6))